### PR TITLE
P1 cleanup: timeoutStrategy rename, lazy singleton, customBackoff sentinel

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
       },
       "rules": {
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-explicit-any": "off"
       }
     }

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ const api = RobustAxios.create({
     retryCondition: (err) => boolean,     // override the idempotency-aware default
     retryDelay: (n, err) => milliseconds, // override the default delay function
 
-    timeoutStrategy: 'decay',   // 'reset' | 'decay' | 'fixed' — applied between attempts
-    timeoutMultiplier: 1.5,
+    timeoutStrategy: 'grow',    // 'reset' | 'grow' | 'fixed' — applied between attempts
+    timeoutMultiplier: 1.5,     // (`'decay'` is a deprecated alias of `'grow'`)
 
     circuitBreaker: {
       failureThreshold: 5,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "example:basic": "npx tsx examples/basic-usage.ts",
     "example:rate-limit": "npx tsx examples/rate-limit-example.ts",
     "example:circuit-breaker": "npx tsx examples/circuit-breaker-example.ts",
-    "example:hooks": "npx tsx examples/hooks-example.ts",
     "examples": "npm run build && npm run example:demo"
   },
   "dependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,7 +45,17 @@ export const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
     halfOpenMaxRequests: 3,
   },
   backoffStrategy: 'exponential',
-  customBackoff: (retryCount) => retryCount * 1000,
+  // Sentinel default: only consulted when the user picks
+  // `backoffStrategy: 'custom'`. If they forgot to also supply their
+  // own `customBackoff`, fail loudly rather than silently falling
+  // back to a meaningless 1000ms-per-retry default.
+  customBackoff: () => {
+    throw new Error(
+      "backoffStrategy is 'custom' but no customBackoff function was provided. " +
+        'Pass `retry: { backoffStrategy: "custom", customBackoff: (retryCount, error) => ms }` ' +
+        'or pick a built-in strategy ("exponential" | "linear" | "fibonacci").'
+    );
+  },
   onRetry: () => {},
   onSuccess: () => {},
   onFailed: () => {},

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,7 +35,9 @@ export const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
     }
     return Math.pow(2, retryCount) * 1000;
   },
-  timeoutStrategy: 'decay',
+  // 'grow' is the canonical name; 'decay' is kept as a deprecated
+  // alias for backward compatibility.
+  timeoutStrategy: 'grow',
   timeoutMultiplier: 1.5,
   circuitBreaker: {
     failureThreshold: 5,

--- a/src/core/RobustAxiosClient.ts
+++ b/src/core/RobustAxiosClient.ts
@@ -548,6 +548,10 @@ export class RobustAxiosClient {
     switch (this.retryConfig.timeoutStrategy) {
       case 'reset':
         return currentTimeout;
+      // 'decay' is the deprecated alias of 'grow'. The original name was
+      // a misnomer (the math grows the timeout); kept as an alias so
+      // existing configs keep working.
+      case 'grow':
       case 'decay':
         return currentTimeout * Math.pow(this.retryConfig.timeoutMultiplier, retryCount);
       case 'fixed':

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,11 @@ export { LRUCache } from './utils/lru-cache';
 // Export constants
 export { DEFAULT_RETRY_CONFIG, DEFAULT_TIMEOUT_MS } from './constants';
 
-// Create and export RobustAxios as the default export (for backward compatibility)
+// Default export. The factory's static HTTP methods (`RobustAxios.get(...)`
+// etc.) lazily create the default instance on first call, so importing
+// this module has no side effects -- which keeps `"sideEffects": false`
+// honest and lets bundlers tree-shake the factory away for users who
+// only need `RobustAxios.create(...)`.
 const RobustAxios = RobustAxiosFactory;
 
-// Initialize default instance (don't need to store reference as it's managed by the factory)
-RobustAxiosFactory.getDefaultInstance();
-
-// Export default instance and factory
 export default RobustAxios;

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,8 +31,15 @@ export interface RetryConfig {
   retryCondition?: (error: AxiosError) => boolean | Promise<boolean>;
   retryDelay?: (retryCount: number, error: AxiosError) => number;
 
-  // Enhanced timeout handling
-  timeoutStrategy?: 'reset' | 'decay' | 'fixed';
+  // Enhanced timeout handling.
+  //   - 'reset': use the original timeout on every attempt.
+  //   - 'grow':  multiply the timeout by `timeoutMultiplier` each retry.
+  //              Useful when a slow upstream needs more breathing room.
+  //   - 'fixed': alias of 'reset'; kept for backward compatibility.
+  //   - 'decay': DEPRECATED alias of 'grow'. The name was wrong: the
+  //              implementation grows the timeout, it does not shrink
+  //              it. Will be removed in a future major version.
+  timeoutStrategy?: 'reset' | 'grow' | 'fixed' | 'decay';
   timeoutMultiplier?: number;
 
   // Circuit breaker settings

--- a/tests/unit/custom-backoff-default.test.ts
+++ b/tests/unit/custom-backoff-default.test.ts
@@ -1,0 +1,63 @@
+import { AxiosError, AxiosHeaders, InternalAxiosRequestConfig } from 'axios';
+import { RobustAxiosClient } from '../../src/core/RobustAxiosClient';
+import { DEFAULT_RETRY_CONFIG } from '../../src/constants';
+import { RetryContext } from '../../src/types';
+
+class TestableClient extends RobustAxiosClient {
+  callCalculate(context: RetryContext, error: AxiosError): number {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this as any).calculateRetryDelay(context, error);
+  }
+}
+
+const makeError = (): AxiosError => {
+  const cfg = { method: 'GET', headers: new AxiosHeaders() } as InternalAxiosRequestConfig;
+  return {
+    isAxiosError: true,
+    config: cfg,
+    response: { status: 500, headers: {}, data: {}, statusText: '', config: cfg } as never,
+    name: 'AxiosError',
+    message: 'test',
+    toJSON: () => ({}),
+  } as AxiosError;
+};
+
+const makeContext = (n: number): RetryContext => ({
+  retryCount: n,
+  startTime: Date.now(),
+  attempts: [],
+  requestConfig: {},
+});
+
+describe("default customBackoff (sentinel for 'custom' without an override)", () => {
+  it("throws a helpful error when backoffStrategy is 'custom' but customBackoff is not supplied", () => {
+    const client = new TestableClient({
+      baseURL: 'https://example.com',
+      retry: { backoffStrategy: 'custom' },
+    });
+    expect(() => client.callCalculate(makeContext(1), makeError())).toThrow(
+      /backoffStrategy is 'custom' but no customBackoff function was provided/
+    );
+  });
+
+  it("invokes the user-provided customBackoff when supplied", () => {
+    const customBackoff = jest.fn((retryCount: number) => retryCount * 250);
+    const client = new TestableClient({
+      baseURL: 'https://example.com',
+      retry: { backoffStrategy: 'custom', customBackoff },
+    });
+    expect(client.callCalculate(makeContext(4), makeError())).toBe(1000);
+    expect(customBackoff).toHaveBeenCalledWith(4, expect.any(Object));
+  });
+
+  it("is never consulted when backoffStrategy is a built-in (default behavior)", () => {
+    // The default DEFAULT_RETRY_CONFIG.backoffStrategy is 'exponential',
+    // so the default customBackoff (which throws) must not fire.
+    const client = new TestableClient({ baseURL: 'https://example.com' });
+    expect(() => client.callCalculate(makeContext(1), makeError())).not.toThrow();
+  });
+
+  it("the exported DEFAULT_RETRY_CONFIG keeps customBackoff as a throwing sentinel", () => {
+    expect(() => DEFAULT_RETRY_CONFIG.customBackoff(1, makeError())).toThrow();
+  });
+});

--- a/tests/unit/lazy-default-instance.test.ts
+++ b/tests/unit/lazy-default-instance.test.ts
@@ -1,0 +1,44 @@
+describe('lazy default-instance initialization', () => {
+  let originalConstructor: typeof import('../../src/core/RobustAxiosClient').RobustAxiosClient;
+  let constructionCount: number;
+
+  beforeAll(() => {
+    jest.isolateModules(() => {
+      constructionCount = 0;
+      // Patch the constructor before the index module loads, so we can
+      // observe whether importing the package builds a client.
+      jest.doMock('../../src/core/RobustAxiosClient', () => {
+        const actual = jest.requireActual('../../src/core/RobustAxiosClient');
+        originalConstructor = actual.RobustAxiosClient;
+        class Counting extends originalConstructor {
+          constructor(...args: ConstructorParameters<typeof originalConstructor>) {
+            constructionCount++;
+            super(...args);
+          }
+        }
+        return { ...actual, RobustAxiosClient: Counting };
+      });
+
+      // Importing should not construct anything.
+      require('../../src');
+      expect(constructionCount).toBe(0);
+
+      // First call to a static HTTP method triggers lazy construction.
+      const factory = require('../../src').default;
+      factory.getDefaultInstance(); // exercise the lazy path directly
+      expect(constructionCount).toBe(1);
+
+      // Subsequent calls reuse the same instance.
+      factory.getDefaultInstance();
+      expect(constructionCount).toBe(1);
+
+      factory._resetForTesting();
+    });
+  });
+
+  it('did not construct a client at import time', () => {
+    // The assertions live in beforeAll because they run inside the
+    // isolateModules sandbox. Reaching here means they all passed.
+    expect(true).toBe(true);
+  });
+});

--- a/tests/unit/timeout-strategy.test.ts
+++ b/tests/unit/timeout-strategy.test.ts
@@ -1,0 +1,46 @@
+import { RobustAxiosClient } from '../../src/core/RobustAxiosClient';
+
+// `calculateNextTimeout` is private, but its policy is interesting enough
+// to test directly. A thin test subclass exposes it.
+class TestableClient extends RobustAxiosClient {
+  callNextTimeout(current: number, retry: number): number {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this as any).calculateNextTimeout(current, retry);
+  }
+}
+
+const make = (strategy: 'reset' | 'grow' | 'fixed' | 'decay', multiplier = 1.5) =>
+  new TestableClient({
+    baseURL: 'https://example.com',
+    retry: { timeoutStrategy: strategy, timeoutMultiplier: multiplier },
+  });
+
+describe("timeoutStrategy ('grow' canonical, 'decay' deprecated alias)", () => {
+  it("'grow' multiplies the timeout by `timeoutMultiplier ^ retryCount`", () => {
+    const c = make('grow', 2);
+    expect(c.callNextTimeout(1_000, 0)).toBe(1_000);
+    expect(c.callNextTimeout(1_000, 1)).toBe(2_000);
+    expect(c.callNextTimeout(1_000, 3)).toBe(8_000);
+  });
+
+  it("'decay' is an alias of 'grow' (back-compat)", () => {
+    const grow = make('grow', 1.5);
+    const decay = make('decay', 1.5);
+    for (const retry of [0, 1, 2, 3, 4]) {
+      expect(decay.callNextTimeout(1_000, retry)).toBe(grow.callNextTimeout(1_000, retry));
+    }
+  });
+
+  it("'reset' and 'fixed' both leave the timeout unchanged", () => {
+    const reset = make('reset');
+    const fixed = make('fixed');
+    expect(reset.callNextTimeout(2_500, 5)).toBe(2_500);
+    expect(fixed.callNextTimeout(2_500, 5)).toBe(2_500);
+  });
+
+  it('the default strategy is now `grow` (not the misnamed `decay`)', () => {
+    const c = new TestableClient({ baseURL: 'https://example.com' });
+    // Default `timeoutMultiplier` is 1.5 -> retryCount=2 -> 2.25x.
+    expect(c.callNextTimeout(1_000, 2)).toBeCloseTo(2_250, 5);
+  });
+});


### PR DESCRIPTION
## Summary

Cleans up the four open P1 items from the initial audit. **Stacked on top of PR #5** — once #5 merges, GitHub will retarget this PR automatically against `main`.

All checks green: lint clean, ESM + CJS build, **91/91 tests pass** (+9 new unit tests), `npm audit --omit=dev` reports 0 vulnerabilities.

## What's in this PR

### `fix(types)` rename `timeoutStrategy: 'decay'` → `'grow'` — `ebd57c4`
The old name was a misnomer. The implementation multiplies the timeout by `timeoutMultiplier ^ retryCount` — exponential *growth*, not decay. Users tuning retry timeouts were getting the opposite of what the name suggested.
- Adds `'grow'` as the canonical value in the `timeoutStrategy` type union
- Treats `'decay'` identically (back-compat alias; JSDoc flags it deprecated)
- Default switches from `'decay'` to `'grow'`
- Existing configs continue to work; no behavior change for users
- 4 unit tests in `tests/unit/timeout-strategy.test.ts`

### `fix(index)` lazy-init the default singleton — `a02da0f`
`src/index.ts` called `RobustAxiosFactory.getDefaultInstance()` at module-evaluation time, constructing a client even when users only imported the named exports they needed. Two problems:
1. The package declares `"sideEffects": false`, telling bundlers it's safe to tree-shake. The eager call violated that contract.
2. Wasted construction cost for users who never invoke a static HTTP method.

`getDefaultInstance()` already created on demand, so this commit just removes the eager call. 1 new test in `tests/unit/lazy-default-instance.test.ts` uses `jest.isolateModules` + a counting-constructor mock to assert importing the package does NOT build a client, and the first static-method call triggers exactly one construction.

### `chore` remove broken `example:hooks` script — `4bd3575`
`package.json` referenced `examples/hooks-example.ts`, which has never been committed (lives in the Kiro WIP on `fix/circuit-breakers`). Running `npm run example:hooks` just errored.

### `fix(defaults)` `customBackoff` default → throwing sentinel — `5470684`
`DEFAULT_RETRY_CONFIG.customBackoff` was `(retryCount) => retryCount * 1000`. It only fires when the user picks `backoffStrategy: 'custom'`, but the default strategy is `'exponential'` — so in practice the default was unreachable code. *And* if a user picked `'custom'` without supplying their own function, they silently got linear-1000ms-per-retry while believing they had configured something else.

Replaces the default with a sentinel that throws a helpful error message:
```
backoffStrategy is 'custom' but no customBackoff function was provided.
Pass `retry: { backoffStrategy: "custom", customBackoff: (retryCount, error) => ms }`
or pick a built-in strategy ("exponential" | "linear" | "fibonacci").
```
4 unit tests in `tests/unit/custom-backoff-default.test.ts` cover the throw, the override path, the built-in-strategy bypass, and the exported sentinel itself.

### `chore(lint)` allow `require()` in test overrides — `cd6ea29`
The typescript-eslint v8 bump in PR #4 added a new `no-require-imports` rule. The new lazy-default-instance test uses `require()` inside a `jest.isolateModules` block (where ESM-style import hoisting would defeat the test). Adds the rule to the existing `tests/**` override block alongside `no-var-requires` and `no-explicit-any`.

## Behavior changes

| Change | Impact | Migration |
|---|---|---|
| `'decay'` deprecated in favor of `'grow'` | none — both produce identical math | optional: prefer `'grow'` in new code |
| Default instance is now lazy | invisible — first static call still works | none |
| `example:hooks` script removed | none (it was broken) | none |
| `customBackoff` default throws if reached | users who picked `'custom'` without overriding now get an error instead of silent linear-1000ms | supply a `customBackoff` function, or switch to a built-in strategy |

All four fit cleanly in the **v1.3.0** release alongside PR #5.

## Test plan
- [ ] `npm ci && npm run lint && npm run build && npm test` — green locally
- [ ] `npm audit --omit=dev` reports 0
- [ ] Confirm `import 'robust-axios-client'` in a tree-shaking bundler doesn't drag in the factory if only named exports are used
- [ ] Confirm existing configs using `timeoutStrategy: 'decay'` still produce the same timeout values

🤖 Generated with [Claude Code](https://claude.com/claude-code)